### PR TITLE
Fixes warning about wrong usage of 'abs' method

### DIFF
--- a/Pod/Classes/NSDate+Additions.m
+++ b/Pod/Classes/NSDate+Additions.m
@@ -181,7 +181,7 @@ static const unsigned componentFlags = (NSCalendarUnitYear| NSCalendarUnitMonth 
 	if (components1.weekOfYear != components2.weekOfYear) return NO;
 	
 	// Must have a time interval under 1 week. Thanks @aclark
-	return (abs([self timeIntervalSinceDate:aDate]) < D_WEEK);
+	return (fabs([self timeIntervalSinceDate:aDate]) < D_WEEK);
 }
 
 - (BOOL) isThisWeek


### PR DESCRIPTION
Fixes XCode warning about using abs instead of fabs. 
