### PR TITLE
fixed iOS8 deprecation tip problem

### DIFF
--- a/NSDate-Additions.podspec
+++ b/NSDate-Additions.podspec
@@ -1,15 +1,6 @@
-#
-# Be sure to run `pod lib lint NSDate-Additions.podspec' to ensure this is a
-# valid spec and remove all comments before submitting the spec.
-#
-# Any lines starting with a # are optional, but encouraged
-#
-# To learn more about a Podspec see http://guides.cocoapods.org/syntax/podspec.html
-#
-
 Pod::Spec.new do |s|
   s.name             = "NSDate-Additions"
-  s.version          = "0.0.10"
+  s.version          = "0.0.11"
   s.summary          = "Helpful additions for NSDate."
   s.description      = <<-DESC
                        Fork from Erica https://github.com/erica/NSDate-Extensions
@@ -26,8 +17,5 @@ Pod::Spec.new do |s|
   s.requires_arc = true
   s.module_name = "NSDate_Additions"
   s.source_files = 'Pod/Classes'
-  s.resource_bundles = {
-    'NSDate-Additions' => ['Pod/Assets/*.png']
-  }
 
 end

--- a/Pod/Classes/NSDate+Additions.m
+++ b/Pod/Classes/NSDate+Additions.m
@@ -14,9 +14,12 @@
 
 #import "NSDate+Additions.h"
 
-// Thanks, AshFurrow
+#ifdef __IPHONE_8_0
 static const unsigned componentFlags = (NSCalendarUnitYear| NSCalendarUnitMonth | NSCalendarUnitDay | NSCalendarUnitWeekOfYear |  NSCalendarUnitHour | NSCalendarUnitMinute | NSCalendarUnitSecond | NSCalendarUnitWeekday | NSCalendarUnitWeekdayOrdinal);
-
+#else
+// Thanks, AshFurrow
+static const unsigned componentFlags = (NSYearCalendarUnit| NSMonthCalendarUnit | NSDayCalendarUnit | NSWeekCalendarUnit |  NSHourCalendarUnit | NSMinuteCalendarUnit | NSSecondCalendarUnit | NSWeekdayCalendarUnit | NSWeekdayOrdinalCalendarUnit);
+#endif
 
 @implementation NSDate (Additions)
 
@@ -159,7 +162,11 @@ static const unsigned componentFlags = (NSCalendarUnitYear| NSCalendarUnitMonth 
 - (BOOL)isTimeEarlierThanTime:(NSDate *)date
 {
     NSCalendar *calendar = [NSCalendar currentCalendar];
+#ifdef __IPHONE_8_0
+    NSInteger comps = (NSCalendarUnitHour | NSCalendarUnitMinute | NSCalendarUnitSecond);
+#else
     NSInteger comps = (NSHourCalendarUnit | NSMinuteCalendarUnit | NSSecondCalendarUnit);
+#endif
     NSDateComponents *fromComponents = [calendar components:comps fromDate:self];
     NSDateComponents *toComponents = [calendar components:comps fromDate:date];
     NSDate *from = [calendar dateFromComponents:fromComponents];
@@ -621,7 +628,13 @@ static const unsigned componentFlags = (NSCalendarUnitYear| NSCalendarUnitMonth 
     NSDate *today = [NSDate date];
     NSCalendar *currentCalendar = [NSCalendar currentCalendar];
     NSDate *startOfQuarter;
-    [currentCalendar rangeOfUnit:NSQuarterCalendarUnit
+    
+#ifdef __IPHONE_8_0
+    NSCalendarUnit unit = NSCalendarUnitQuarter;
+#else
+    NSCalendarUnit unit = NSQuarterCalendarUnit;
+#endif
+    [currentCalendar rangeOfUnit:unit
                        startDate:&startOfQuarter
                         interval:NULL
                          forDate:today];
@@ -646,7 +659,13 @@ static const unsigned componentFlags = (NSCalendarUnitYear| NSCalendarUnitMonth 
 + (NSDate *)dateAtStartOfPreviousQuarter {
     NSCalendar *currentCalendar = [NSCalendar currentCalendar];
     NSDate *startOfQuarter;
-    [currentCalendar rangeOfUnit:NSQuarterCalendarUnit
+#ifdef __IPHONE_8_0
+    NSCalendarUnit unit = NSCalendarUnitQuarter;
+#else
+    NSCalendarUnit unit = NSQuarterCalendarUnit;
+#endif
+
+    [currentCalendar rangeOfUnit:unit
                        startDate:&startOfQuarter
                         interval:NULL
                          forDate:[self dateAtEndOfPreviousQuarter]];


### PR DESCRIPTION
We updated Xcode to 8.0 which's lowest deployment version is iOS8.
When we try to lint our podspecs which depends on NSDate-Additions, linter will throw some warnings about `NSCalendarUnit`.
So I modified some code about that makes it compatible with both the origin case and the new one like mine.
